### PR TITLE
Fix: redundant a:hover rule in custom.css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -208,10 +208,6 @@ a {
   transition: all 0.25s ease-out !important;
 }
 
-a:hover {
-  text-decoration: none;
-}
-
 .menu__link--no-hover {
   color: var(--primary-text-color);
 }


### PR DESCRIPTION
This commit addresses the redundancy in the `custom.css` file by removing the duplicate `a:hover` rule. The changes ensure a cleaner and more efficient stylesheet while maintaining the intended hover effect.

### Changes:
- Removed the duplicate `a:hover` selector from `custom.css`.