### PR TITLE
Fix typos in documentation and configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 5.9.0 - 2025-04-24
+
+### Changed
+- Fix typos in documentation and configuration files
+
+### Fixed
+  - Corrected "informations" to "information" in nginx configuration
+  - Fixed "inheretance" to "inheritance" in nginx header comment
+  - Fixed "BlobSubmitionOperator" to "BlobSubmissionOperator" in network info documentation
+
 ## [5.9.0] - 2025-04-15
 ### Changed
 - Use the new lib for React in the proof of citizenship guide;

--- a/docs/zk-registry/network-info.mdx
+++ b/docs/zk-registry/network-info.mdx
@@ -38,7 +38,7 @@ import TabItem from '@theme/TabItem';
 - **Deployer**: <OutLink href="https://etherscan.io/address/0xBbEF10cEA9eEFD021069a1fC4A348c00e799b01b">`0xBbEF10cEA9eEFD021069a1fC4A348c00e799b01b`</OutLink>
 - **RollupSecurityCouncil**: <OutLink href="https://etherscan.io/address/0xBbEF10cEA9eEFD021069a1fC4A348c00e799b01b">`0xBbEF10cEA9eEFD021069a1fC4A348c00e799b01b`</OutLink>
 - **FinalizationOperator**: <OutLink href="https://etherscan.io/address/0x3Cbe03D5BFc55b47e332B9Ff71feBa0F0e2133Dd">`0x3Cbe03D5BFc55b47e332B9Ff71feBa0F0e2133Dd`</OutLink>
-- **BlobSubmitionOperator**: <OutLink href="https://etherscan.io/address/0x558AbE76A8258b55F14e5e16C92b6f6b087dEa0e">`0x558AbE76A8258b55F14e5e16C92b6f6b087dEa0e`</OutLink>
+- **BlobSubmissionOperator**: <OutLink href="https://etherscan.io/address/0x558AbE76A8258b55F14e5e16C92b6f6b087dEa0e">`0x558AbE76A8258b55F14e5e16C92b6f6b087dEa0e`</OutLink>
 - **Postman**: <OutLink href="https://etherscan.io/address/0xC974Ab7d1022a8532931f3078045b94EdBdC8d6d">`0xC974Ab7d1022a8532931f3078045b94EdBdC8d6d`</OutLink>
 
 ## L2 address book

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,7 @@ http {
     fastcgi_temp_path     /tmp/nginx-fastcgi;
     uwsgi_temp_path       /tmp/nginx-uwsgi;
     scgi_temp_path        /tmp/nginx-scgi;
-    # cache informations about FDs, frequently accessed files
+    # cache information about FDs, frequently accessed files
     # can boost performance, but you need to test those values
     open_file_cache max=200000 inactive=20s;
     open_file_cache_valid 30s;
@@ -115,7 +115,7 @@ http {
 
         location /assets {
             add_header Cache-Control "public,max-age=31536000,immutable";
-            # NOTE: duplicating the headers from aboive to fix the nginx header inheretance caveat
+            # NOTE: duplicating the headers from aboive to fix the nginx header inheritance caveat
             # Security headers
             add_header X-Frame-Options "DENY";
             add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
This PR includes the following fixes:

1. In docs/zk-registry/network-info.mdx:
- Fixed typo: "BlobSubmitionOperator" -> "BlobSubmissionOperator"

2. In nginx.conf:
- Fixed typo: "informations" -> "information"
- Fixed typo: "inheretance" -> "inheritance"

These changes are minor text corrections to improve documentation accuracy.